### PR TITLE
Add Accuracy metrics log to std output

### DIFF
--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -227,7 +227,7 @@ class Loggers():
         x = dict(zip(self.keys, vals))
 
         print(
-            f"Epoch: {epoch}, Training Loss: {vals[0].cpu().numpy().tolist()}, Validation Loss: {vals[7]}, Validation Precision: {vals[3]}, Validation Recall: {vals[4]}, Validation mAP_0.5: {vals[5]}, Validation metrics/mAP_0.5:0.95: {vals[6]}"
+            f"Epoch: {epoch}, Training Loss: {vals[0].cpu().numpy().tolist()}, Validation Loss: {vals[7]}, Validation mAP_0.5: {vals[5]}, Validation mAP_0.5:0.95: {vals[6]}"
         )
 
         if self.csv:

--- a/utils/loggers/__init__.py
+++ b/utils/loggers/__init__.py
@@ -227,7 +227,7 @@ class Loggers():
         x = dict(zip(self.keys, vals))
 
         print(
-            f"Epoch: {epoch}, Training Loss: {vals[0].cpu().numpy().tolist()}, Validation Loss: {vals[7]}"
+            f"Epoch: {epoch}, Training Loss: {vals[0].cpu().numpy().tolist()}, Validation Loss: {vals[7]}, Validation Precision: {vals[3]}, Validation Recall: {vals[4]}, Validation mAP_0.5: {vals[5]}, Validation metrics/mAP_0.5:0.95: {vals[6]}"
         )
 
         if self.csv:


### PR DESCRIPTION
## 背景
YOLOv5の学習で、mAPを標準出力できるようにした。

## リンク
https://www.notion.so/fastlabel/accuracy-1f671e73a4ea43d69ab58016022f243a

## 対応内容
すでに"mAP_0.5"と"mAP_0.5:0.95"の計算コードがあったので、計算結果を標準出力するように変更した。

## テスト
sagemakerで以下のような出力が得られることを確認した。
![スクリーンショット 2024-03-21 22 38 23](https://github.com/fastlabel/yolov5/assets/30709718/ee229bca-dc8a-4d68-9941-6de0032d5882)


